### PR TITLE
Fix Medium posts plugin crashing the Pages deploy on empty/failed feed

### DIFF
--- a/_plugins/jekyll-display-medium-posts-json.rb
+++ b/_plugins/jekyll-display-medium-posts-json.rb
@@ -6,16 +6,29 @@ module Jekyll
   class JekyllDisplayMediumPosts < Generator
     safe true
     priority :high
-def generate(site)
+    def generate(site)
       jekyll_coll = Jekyll::Collection.new(site, 'medium_posts_json')
       site.collections['medium_posts_json'] = jekyll_coll
       uri = URI("https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/airlabcmu")
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      request = Net::HTTP::Get.new(uri)
-      response = http.request(request)
-      data = JSON.parse(response.read_body)
-      data['items'].each do |item|
+      begin
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.open_timeout = 10
+        http.read_timeout = 15
+        request = Net::HTTP::Get.new(uri)
+        response = http.request(request)
+        data = JSON.parse(response.read_body)
+      rescue StandardError => e
+        Jekyll.logger.warn 'MediumPosts:', "fetch/parse failed (#{e.class}: #{e.message}); skipping Medium posts"
+        return
+      end
+      items = data.is_a?(Hash) ? data['items'] : nil
+      unless items.is_a?(Array)
+        status = data.is_a?(Hash) ? data['status'] : 'n/a'
+        Jekyll.logger.warn 'MediumPosts:', "rss2json returned no items (status=#{status}); skipping Medium posts"
+        return
+      end
+      items.each do |item|
         title = item['title']
         path = "./medium_posts/" + title + ".md"
         path = site.in_source_dir(path)
@@ -28,7 +41,7 @@ def generate(site)
         doc.data['categories'] = item['categories'];
         html_document = Nokogiri::HTML.fragment(item['description']);
         doc.data['description'] = html_document.search('p').to_html;
-        img_srcs = html_document.css('img').map{ |i| i['src'] } 
+        img_srcs = html_document.css('img').map{ |i| i['src'] }
         doc.data['image'] = img_srcs[0];#item['thumbnail'];
         jekyll_coll.docs << doc
       end


### PR DESCRIPTION
## Problem

The **Deploy Jekyll site to Pages** workflow has been failing (e.g. the run on the #128 merge):

```
_plugins/jekyll-display-medium-posts-json.rb:18:in `generate': undefined method `each' for nil:NilClass (NoMethodError)
```

The generator fetches the AirLab Medium feed through `api.rss2json.com` and iterates `data['items']`. When that request fails or is rate-limited (which happens on the GitHub Actions runner), the returned JSON has no `items` key, so `nil.each` crashes the entire build. It is unrelated to page content — it just surfaced on the first deploy since June 12.

## Fix

- Wrap the HTTP fetch + JSON parse in `begin/rescue` (with open/read timeouts).
- Guard that `items` is an `Array`; if the fetch fails or returns no items, log a warning and **skip** the Medium posts instead of aborting the build.

## Testing

Built locally with the repo's `docker-compose` (`ruby:3.2`, `bundle exec jekyll serve`): the build completes (`done in ~113s`), serves on `:4000`, and `/`, `/team/mukai_yu`, and `/img/team/*` all return HTTP 200. Without the fix the crash reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
